### PR TITLE
Closes #61 and 60. Metrics in /status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Common issues when running tests:
 2. `HMAC error`: The key in CouchDB configuration for `jwt_keys/hmac:_default` does not match `ACCESS_JWT_SIGN_PK` in `.env`
 
 
-## Testing a deplyed node
+## Testing a deployed node
 
 To test a deployed node, do the following
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ docker buildx build --platform linux/amd64,linux/arm64 --push -t verida/storage-
 
 Run tests with `yarn run tests`
 
+You will need to update `/test/config.js` with at least the `VDA_PRIVATE_KEY`, `DID_CLIENT_CONFIG.web3Config.privateKey` 
+and possibily `ENDPOINTS` and `SERVER_URL`.
+
 Common issues when running tests:
 
 1. `Bad key`: The key in CouchDB configuration for `jwt_keys/hmac:_default` is not a valid Base64 encoded key
@@ -166,5 +169,5 @@ Common issues when running tests:
 
 To test a deployed node, do the following
 
-* Modify `tests/config.js` with the correct endpoint URLs
+* Modify `test/config.js` with the correct endpoint URLs
 * Run `yarn test test/server.js`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verida/storage-node",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Verida Storage Node middleware that bridges decentralised identities so they can control access to databases within a CouchDB storage engine",
   "main": "dist/server.js",
   "scripts": {

--- a/src/build.js
+++ b/src/build.js
@@ -1,1 +1,1 @@
-export const BUILD_DETAILS = {buildTimestamp: "2023-05-04T01:33:06+00:00"};
+export const BUILD_DETAILS = {buildTimestamp: "2023-07-21T04:18:40+00:00"};

--- a/src/components/db.js
+++ b/src/components/db.js
@@ -1,8 +1,5 @@
-import dotenv from 'dotenv';
-import CouchDb from 'nano';
 import Axios from 'axios';
-
-dotenv.config();
+import CouchDb from 'nano';
 
 class Db {
 
@@ -48,6 +45,23 @@ class Db {
         const usersDb = couch.db.use('_users')
         const info = await usersDb.info()
         return info.doc_count
+    }
+
+    // Get some useful couch statistics and metrics to include in the status
+    async getCouchStats() {
+        const dsn = this.buildDsn(process.env.DB_USER, process.env.DB_PASS, 'internal');
+
+        try {
+            const metrics = await Axios.get(`${dsn}/_node/_local/_stats/couchdb/`);
+            return {
+                requestMeanTimeMS: metrics.data['request_time']['value']['arithmetic_mean'],
+                requestTimeStdDevMS: metrics.data['request_time']['value']['standard_deviation'],
+                continuousChangesClientCount: metrics.data['httpd']['clients_requesting_changes']['value']
+            }
+        } catch (err) {
+            console.log(err);
+            return undefined
+        }
     }
 
 }

--- a/src/controllers/system.js
+++ b/src/controllers/system.js
@@ -17,7 +17,7 @@ class SystemController {
         const wallet = new ethers.Wallet(process.env.VDA_PRIVATE_KEY)
 
         const results = {
-            maxUsers: parseInt(process.env.MAX_USERS),
+            maxStorageSlots: parseInt(process.env.MAX_USERS),
             storageSlotsUsed,
             metrics: metrics,
             version: packageJson.version,

--- a/src/controllers/system.js
+++ b/src/controllers/system.js
@@ -12,12 +12,14 @@ import { BUILD_DETAILS } from '../build';
 class SystemController {
 
     async status(req, res) {
-        const currentUsers = await db.totalUsers()
+        const storageSlotsUsed = await db.totalUsers();
+        const metrics = await db.getCouchStats();
         const wallet = new ethers.Wallet(process.env.VDA_PRIVATE_KEY)
 
         const results = {
             maxUsers: parseInt(process.env.MAX_USERS),
-            currentUsers,
+            storageSlotsUsed,
+            metrics: metrics,
             version: packageJson.version,
             publicKey: wallet.publicKey,
             couchUri: db.buildHost(),

--- a/test/server.js
+++ b/test/server.js
@@ -354,9 +354,13 @@ describe("Server tests", function() {
         it("Status", async () => {
             const response = await Axios.get(`${SERVER_URL}/status`);
 
-            assert.equal(response.data.results.maxUsers, process.env.MAX_USERS, 'Correct maximum number of users')
-            assert.ok(response.data.results.currentUsers > 2, 'At least two users')
-            assert.ok(response.data.results.version && response.data.results.version.length, 'Version specified')
+            assert.equal(response.data.results.maxUsers, process.env.MAX_USERS, 'Correct maximum number of users');
+            assert.ok(response.data.results.currentUsers > 2, 'At least two users');
+            assert.ok(response.data.results.version && response.data.results.version.length, 'Version specified');
+            assert.ok(response.data.results.metrics && response.data.results.metrics.length === 3, 'Metrics exist');
+            assert.ok(response.data.results.metrics.continuousChangesClientCount >= 0, 'Metric continuousChangesClientCount is in expected range');
+            assert.ok(response.data.results.metrics.requestMeanTimeMS >= 0, 'Metric requestMeanTimeMS is in expected range');
+            assert.ok(response.data.results.metrics.requestTimeStdDevMS >= 0, 'Metric requestTimeStdDevMS is in expected range');
         })
     })
 })


### PR DESCRIPTION
This PR does the following:

adds a `metrics` section to the `/status` endpoint that looks like this:

```
    "metrics": {
      "continuousChangesClientCount": 0,
      "requestMeanTimeMS": 18.60266666666667,
      "requestTimeStdDevMS": 9.064928121400293
    }
```

This fixes #61 

Additionally, it changes the fields:
* `currentUsers` to `maxStorageSlots`
* `maxUsers` to `maxStorageSlots`

It doesn't change the config field name for that field. We could do that as a separate update at some stage, but a lot of the code refers to the limit as "maxUsers" so I'm not sure which would be less confusing. 

Once this PR is merged and deployed I'll need to update https://github.com/verida/metrics/blob/d6dec1f57ed14af5dd8e7628839a9e3832f63a87/mergestats/src/index.ts#L35 and related code to use it correctly. I think that is the only code depending on it at the moment. 