### PR TITLE
duplicate data to maxUsers and currentUsers fields for backwards comptibility

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -1,1 +1,1 @@
-export const BUILD_DETAILS = {buildTimestamp: "2023-07-21T04:18:40+00:00"};
+export const BUILD_DETAILS = {buildTimestamp: "2023-07-31T00:48:27+00:00"};

--- a/src/controllers/system.js
+++ b/src/controllers/system.js
@@ -18,7 +18,9 @@ class SystemController {
 
         const results = {
             maxStorageSlots: parseInt(process.env.MAX_USERS),
-            storageSlotsUsed,
+            maxUsers: parseInt(process.env.MAX_USERS),
+            storageSlotsUsed: storageSlotsUsed,
+            currentUsers: storageSlotsUsed,
             metrics: metrics,
             version: packageJson.version,
             publicKey: wallet.publicKey,


### PR DESCRIPTION
Emergency fix so the protocol doesn't break with the change to these fields. 